### PR TITLE
beginEdit / endEdit don't need PLUGIN_API

### DIFF
--- a/cpp/src/controller.cpp
+++ b/cpp/src/controller.cpp
@@ -468,7 +468,7 @@ tresult PLUGIN_API Controller::setComponentState(IBStream *state) {
     return kResultOk;
 }
 
-tresult PLUGIN_API Controller::beginEdit(ParamID tag) {
+tresult Controller::beginEdit(ParamID tag) {
     if (tag == kPitchBend) {
         if (pbSpringState_ == PbSpring::Springing) {
             // User grabbed the pitch bend mid-animation. Kill the timer and
@@ -483,7 +483,7 @@ tresult PLUGIN_API Controller::beginEdit(ParamID tag) {
     return EditController::beginEdit(tag);
 }
 
-tresult PLUGIN_API Controller::endEdit(ParamID tag) {
+tresult Controller::endEdit(ParamID tag) {
     tresult result = EditController::endEdit(tag);
     if (tag == kPitchBend && pbSpringState_ == PbSpring::UserDragging) {
         pbSpringState_ = PbSpring::Idle;

--- a/cpp/src/controller.h
+++ b/cpp/src/controller.h
@@ -89,8 +89,8 @@ class Controller : public Steinberg::Vst::EditController,
     Steinberg::tresult PLUGIN_API setParamNormalized(Steinberg::Vst::ParamID tag,
                                                      Steinberg::Vst::ParamValue value) override;
     Steinberg::tresult PLUGIN_API setComponentState(Steinberg::IBStream *state) override;
-    Steinberg::tresult PLUGIN_API beginEdit(Steinberg::Vst::ParamID tag) override;
-    Steinberg::tresult PLUGIN_API endEdit(Steinberg::Vst::ParamID tag) override;
+    Steinberg::tresult beginEdit(Steinberg::Vst::ParamID tag) override;
+    Steinberg::tresult endEdit(Steinberg::Vst::ParamID tag) override;
 
     // VST3EditorDelegate overrides
     VSTGUI::CView *createCustomView(UTF8StringPtr name, const VSTGUI::UIAttributes &attributes,


### PR DESCRIPTION
To compile as a 32bit Windows VST3 PlugIn, the PLUGIN_API definition has to be removed from `Controller::beginEdit` and `Controller::endEdit`. See the corresponding definitions in vst3sdk-src\public.sdk\source\vst\vsteditcontroller.h:
```C++
	//---Internal Methods-------
	virtual tresult beginEdit (ParamID tag);	///< to be called before a serie of performEdit
	...
	virtual tresult endEdit (ParamID tag);		///< to be called after a serie of performEdit
```
For 64bit builds (x64 / ARM64), deriving from that with
```C++
    Steinberg::tresult PLUGIN_API beginEdit(Steinberg::Vst::ParamID tag) override;
    Steinberg::tresult PLUGIN_API endEdit(Steinberg::Vst::ParamID tag) override;
```
works, but only because PLUGIN_API is preprocessed to __stdcall there, which is standard anyway.